### PR TITLE
Cu-18804ry_appConfigHydrate

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,7 +25,7 @@ import {
     setPreferences
 } from './slices/recipePreferences'
 import { selectionModeSlice } from './slices/selectionMode'
-import { DayMealPlan } from './types/DayMealPlan'
+import { DayMealPlan, getBlankDayMealPlan } from './types/DayMealPlan'
 import { RecipePreferences } from './types/RecipePreferences'
 
 /** The AppConfig context */
@@ -62,6 +62,18 @@ export const useAppStore = () => useStore<AppState>()
 const LS_DAY_MEAL_PLANS = 'dayMealPlans'
 
 const hydrateDayMealPlans = () => {
+    // begin with a week's worth of plans starting from today's date
+
+    const newPlans = [0, 1, 2, 3, 4, 5, 6, 7, 8].map(dayIndex => {
+        const date = new Date()
+        date.setDate(date.getDate() + dayIndex)
+        return getBlankDayMealPlan(date, appConfig.meals)
+    })
+
+    store.dispatch(mergeDayMealPlans({ plans: newPlans }))
+
+    // load old plans from localStorage
+
     console.log('loading oldDayMealPlans from localStorage')
     const oldDayMealPlansJSON = localStorage.getItem(LS_DAY_MEAL_PLANS)
     if (oldDayMealPlansJSON !== null) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,7 +18,12 @@ import { dayMealPlansSlice, mergeDayMealPlans } from './slices/dayMealPlans'
 import { fullRecipesSlice } from './slices/fullRecipes'
 import { homeScreensSlice } from './slices/homeScreens'
 import { recipeBookSlice } from './slices/recipeBook'
-import { recipeListsSlice } from './slices/recipeLists'
+import {
+    recipeListsSlice,
+    RecipeListsState,
+    setFetchLimit,
+    setRecipeLists
+} from './slices/recipeLists'
 import {
     recipePreferencesSlice,
     setCompletedOnboarding,
@@ -111,6 +116,28 @@ const getWriteDayMealPlans = () => {
 }
 
 store.subscribe(getWriteDayMealPlans())
+
+/** Hydrate recipeLists using appConfg */
+
+const hydrateRecipeLists = () => {
+    // create list objects from config
+
+    const lists: RecipeListsState['lists'] = appConfig.recipeLists.map(
+        ({ name, type }) => ({
+            name,
+            type,
+            currentOffset: 0,
+            recipesByOffset: []
+        })
+    )
+    store.dispatch(setRecipeLists({ lists }))
+
+    // set fetchLimit from config
+
+    store.dispatch(setFetchLimit({ fetchLimit: appConfig.recipeListLimit }))
+}
+
+hydrateRecipeLists()
 
 /** Hydrate recipePreferences from localStorage */
 

--- a/src/slices/dayMealPlans.ts
+++ b/src/slices/dayMealPlans.ts
@@ -1,9 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
-import { appConfig } from '../appConfig'
 import { RecipeOverview } from '../client/RecipeOverview'
 import {
     DayMealPlan,
-    getBlankDayMealPlan,
     getRecipeSelection,
     isPlanForDate,
     MealPlan,
@@ -16,11 +14,7 @@ export type DayMealPlansState = {
 }
 
 const initialState: DayMealPlansState = {
-    plans: [0, 1, 2, 3, 4, 5, 6, 7, 8].map(dayIndex => {
-        const date = new Date()
-        date.setDate(date.getDate() + dayIndex)
-        return getBlankDayMealPlan(date, appConfig.meals)
-    })
+    plans: []
 }
 
 const findMealPlan = (


### PR DESCRIPTION
The relevant slices (dayMealPlans and recipeLists) no longer import the app config; the relevant values are dispatched into them in index.tsx.

A question and a thought:
 - Is it bad practice to export the slice's State type (i..e, DayMealPlansState or RecipeListsState) from the slice modules? I'm using it in index.tsx to type the values to be dispatched to the store.
 - Redux Toolkit's use of immer in the slice reducers forces all array types to be mutable, so trying to assign a readonly array to a mutable type throws ts errors and is a real pain, forcing more complicated reducer code (i.m.o. they should have a version of createSlice without 'mutating' reducers, [but the maintainer made clear that won't happen](https://github.com/reduxjs/redux-toolkit/issues/242)).

Notes:
 - Added a fetchLimit value to the RecipeListsState; in the future we could add the option for the user to choose to load 5, 10, 25, or whatever numbers of recipes at a time if they like (or not).
 - In the future, the state hydration logic should be moved from index.tsx to a separate module, probably as a function taking the appConfig as a parameter (and anything else needed).